### PR TITLE
Adress remaining comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Today, best practice relies on the use of `aria-details` to identify the link to
 - The image should have a brief `alt` and an `aria-details` attribute pointing to the link's ID.
 - The link should have a unique ID.
 - In the external file, each description is in a `section` with a matching ID, a heading, a presentational copy of the image, the detailed description, and a backlink (`role="doc-backlink"`) to the main content.
-- Note: WAI-ARIA 1.2 specifies that content referenced by `aria-details` is not flattened into accessible name/description computation; it is intended to expose structured, potentially complex descriptions for discovery and navigation (see ARIA `aria-details` in References). Authors should ensure the referenced link is visible to all users and test the pattern across common reading systems and screen readers because user agent and AT support can vary.
+- Note: `aria-details` is designed to reference structured, potentially complex descriptions that may include multiple sections or rich markup. Authors should ensure the referenced link is visible to all users and test the pattern across common reading systems and screen readers because user agent and AT support can vary.
 
 ### Current limitations
 


### PR DESCRIPTION
Closes #3 

> User-Facing Problem section: I would emphasize that there is a standard way to insert alt-text, but not for extended descriptions. Also, add the user of the reading solution developer who would like to provide a dedicated experience for reading extended descriptions.

> User research section: add a link to DAISY best practices?

> Recommended technique section: identify link with aria-details: it talks about in-document anchors, but in reality, the DAISY document recommends managing extended descriptions in a separate file; perhaps the fact that extended descriptions are suggested separately is something that needs to be explained more clearly.

> Recommended technique section: identify link with aria-details: the WAI-ARIA 1.2 note is not clear to me.

> The footnote precedent section: I would explain that thanks to this declarative semantics, reading solutions can enable specific UX features (which, for example, allow the user to keep their place in the text), but even if they do not, the system still works with links, so that the screenshots are clearer.